### PR TITLE
For generating the documentation also coderay has to be installed as gem

### DIFF
--- a/brix11/lib/brix11/brix/common/docs/generate_documentation.rd
+++ b/brix11/lib/brix11/brix/common/docs/generate_documentation.rd
@@ -21,6 +21,6 @@ common
  == Description
 
 Generate documentation from ASCIIDoctor sources into the 'docs' directory. To install
-ASCIIDoctor as gem run the following command
+ASCIIDoctor with coderay support as gem run the following command
 
-$ gem install asciidoctor
+$ gem install asciidoctor coderay


### PR DESCRIPTION
    * brix11/lib/brix11/brix/common/docs/generate_documentation.rd: