### PR TITLE
When TAOX11_ROOT has been defined, use it for determining the MPC.cfg…

### DIFF
--- a/brix11/lib/brix11/brix/common/cmds/configure/mpc_config.rb
+++ b/brix11/lib/brix11/brix/common/cmds/configure/mpc_config.rb
@@ -19,7 +19,11 @@ module BRIX11
         MWCCFG = 'workspace'
 
         def self.create_config(cfg)
-          mpccfg = File.join(Configurator::ROOT, 'taox11', 'bin', 'MPC', 'config', MPCCFG)
+          if Exec.get_run_environment('TAOX11_ROOT')
+            mpccfg = File.join(Exec.get_run_environment('TAOX11_ROOT'), 'bin', 'MPC', 'config', MPCCFG)
+          else
+            mpccfg = File.join(Configurator::ROOT, 'taox11', 'bin', 'MPC', 'config', MPCCFG)
+          end
           # backup current file
           Util.backup_file(mpccfg) unless cfg.dryrun?
           # collect list of configured MPC include folders for enabled modules


### PR DESCRIPTION
… path

    * brix11/lib/brix11/brix/common/cmds/configure/mpc_config.rb: