### PR TITLE
Remove boost=0 from the default generation, not required for X11

### DIFF
--- a/brix11/lib/brix11/brix/common/cmds/configure/hostsetup.rb
+++ b/brix11/lib/brix11/brix/common/cmds/configure/hostsetup.rb
@@ -109,7 +109,6 @@ module BRIX11
                   no_deprecated=0
                   inline=1
                   optimize=1
-                  boost=0
                 }.gsub(/^\s+/, '')
                 platform_macros_io.puts('include $(ACE_ROOT)/include/makeinclude/platform_linux.GNU')
               ensure

--- a/brix11/lib/brix11/brix/common/cmds/configure/platform.rb
+++ b/brix11/lib/brix11/brix/common/cmds/configure/platform.rb
@@ -55,7 +55,6 @@ module BRIX11
                                                     no_deprecated=0
                                                     inline=1
                                                     optimize=1
-                                                    boost=0
                                                   }.gsub(/^\s+/, '')
                                               })
                                             })
@@ -122,7 +121,6 @@ module BRIX11
                                               no_deprecated=0
                                               inline=1
                                               optimize=1
-                                              boost=0
                                             }.gsub(/^\s+/, '')
                                         })
                                         opts[:platform][:bits] = (opts[:platform][:arch] == 'x86_64' ? 64 : 32)


### PR DESCRIPTION
    * brix11/lib/brix11/brix/common/cmds/configure/hostsetup.rb:
    * brix11/lib/brix11/brix/common/cmds/configure/platform.rb: