### PR TITLE
Fix missing proper propagation of subprocess error returns.

### DIFF
--- a/bin/brix11
+++ b/bin/brix11
@@ -31,7 +31,7 @@ end
 
 if __FILE__ == $0
 
-  BRIX11.run
+  exit(1) unless BRIX11.run
 
 end
 

--- a/brix11/lib/brix11.rb
+++ b/brix11/lib/brix11.rb
@@ -28,5 +28,5 @@ end
 require 'brix11/base'
 
 if $0 == __FILE__
-  BRIX11.run
+  exit(1) unless BRIX11.run
 end

--- a/brix11/lib/brix11/base.rb
+++ b/brix11/lib/brix11/base.rb
@@ -302,6 +302,8 @@ module BRIX11
     ensure
       options.logfile.close if options.logfile
     end
+    log(2, "run -> rc=#{rc}")
+    rc
   end
 
   def self.execute(argv)


### PR DESCRIPTION
    * bin/brix11:
    * brix11/lib/brix11.rb:
    * brix11/lib/brix11/base.rb: