### PR TITLE
No excludes for Id tag, should not be used at all

### DIFF
--- a/bin/fuzzers/check_id_tag.excludes
+++ b/bin/fuzzers/check_id_tag.excludes
@@ -1,4 +1,0 @@
-.*(C|S|P|SP)\.(h|inl|cpp)
-taox11\/tests\/.*\/tao\/.*
-ridl\/.*
-taox11/bin/MPC/templates/gnu


### PR DESCRIPTION
    * bin/fuzzers/check_id_tag.excludes: