### PR TITLE
asciidoctor 2.0.11 requires ruby 2.3.0 or newer which breaks our …

### DIFF
--- a/brix11/lib/brix11/brix/common/cmds/gendoc.rb
+++ b/brix11/lib/brix11/brix/common/cmds/gendoc.rb
@@ -30,7 +30,7 @@ module BRIX11
           require 'asciidoctor'
           require 'asciidoctor/extensions'
         rescue LoadError
-          BRIX11.log_fatal("This command requires the installation of the ASCIIDoctor GEM!")
+          BRIX11.log_fatal("This command requires the installation of the Asciidoctor 2.0.10 gem!")
         end
         # load document generator(s)
         Dir.glob(File.join(ROOT, 'cmds', 'gendoc', '*.rb')).each { |p| require "brix/common/cmds/gendoc/#{File.basename(p)}"}

--- a/brix11/lib/brix11/brix/common/docs/generate_documentation.rd
+++ b/brix11/lib/brix11/brix/common/docs/generate_documentation.rd
@@ -20,7 +20,7 @@ common
 
  == Description
 
-Generate documentation from ASCIIDoctor sources into the 'docs' directory. To install
-ASCIIDoctor with coderay support as gem run the following command
+Generate documentation from Asciidoctor sources into the 'docs' directory. To install
+Asciidoctor with coderay support as gem run the following command
 
-$ gem install asciidoctor coderay
+$ gem install asciidoctor:2.0.10 coderay


### PR DESCRIPTION
…rhel7 support, updated instructions to explictly refer to asciidoctor 2.0.10

    * brix11/lib/brix11/brix/common/cmds/gendoc.rb:
    * brix11/lib/brix11/brix/common/docs/generate_documentation.rd: