### PR TITLE
Add support for defining the MPC dynamic_types through each separate …

### DIFF
--- a/brix11/lib/brix11/brix/common/cmds/configure/configurator.rb
+++ b/brix11/lib/brix11/brix/common/cmds/configure/configurator.rb
@@ -260,6 +260,10 @@ module BRIX11
             @rcspec.mpc_include
           end
 
+          def mpc_dynamic_type
+            @rcspec.mpc_dynamic_type
+          end
+
           def mwc_include
             @rcspec.mwc_include
           end

--- a/brix11/lib/brix11/brix/common/cmds/configure/dsl.rb
+++ b/brix11/lib/brix11/brix/common/cmds/configure/dsl.rb
@@ -364,6 +364,9 @@ module BRIX11
               # expand specified path relative to rcfile folder
               @rc.mpc_base = File.expand_path(path.to_s, @base)
             end
+            def dynamic_type(*args)
+              @rc.mpc_dynamic_type.concat(args.flatten.collect {|p| p.start_with?('$') ? p : File.expand_path(p, @base)})
+            end
             def mwc_include(*args)
               args.each do |arg|
                 case arg
@@ -407,6 +410,7 @@ module BRIX11
           @brix_path = []
           @mpc_base = nil
           @mpc_include = []
+          @mpc_dynamic_type = []
           @mwc_include = {}
           DSLHandler.new(self).instance_eval(&block)
         end
@@ -420,6 +424,7 @@ module BRIX11
                     :ridl_be_path,
                     :brix_path,
                     :mpc_include,
+                    :mpc_dynamic_type,
                     :mwc_include
 
         attr_accessor :mpc_base

--- a/brix11/lib/brix11/brix/common/cmds/configure/mpc_config.rb
+++ b/brix11/lib/brix11/brix/common/cmds/configure/mpc_config.rb
@@ -30,13 +30,17 @@ module BRIX11
           mpcinc = cfg.cfglist.values.collect do |mod|
             mod.mpc_include
           end.flatten
+          # collect list of configured MPC dynamic types folders for enabled modules
+          mpcdynamic = cfg.cfglist.values.collect do |mod|
+            mod.mpc_dynamic_type
+          end.flatten
           # generate mpc config file
           BRIX11.show_msg("Creating #{mpccfg}")
           begin
             mpccfg_io = cfg.dryrun? ? STDOUT : File.new(mpccfg, 'w')
             mpccfg_io.puts("//----- #{MPCCFG} -----") if cfg.dryrun?
             mpccfg_io.puts("includes = #{mpcinc.join(', ')}")
-            mpccfg_io.puts('dynamic_types = $MPC_ROOT, $TAO_ROOT/MPC, $TAOX11_ROOT/bin/MPC')
+            mpccfg_io.puts("dynamic_types = #{mpcdynamic.join(', ')}")
             mpccfg_io.puts('main_functions = cplusplus:ACE_TMAIN')
           ensure
             mpccfg_io.close unless cfg.dryrun?

--- a/brix11/lib/brix11/brix/common/cmds/configure/mpc_config.rb
+++ b/brix11/lib/brix11/brix/common/cmds/configure/mpc_config.rb
@@ -40,7 +40,7 @@ module BRIX11
             mpccfg_io = cfg.dryrun? ? STDOUT : File.new(mpccfg, 'w')
             mpccfg_io.puts("//----- #{MPCCFG} -----") if cfg.dryrun?
             mpccfg_io.puts("includes = #{mpcinc.join(', ')}")
-            mpccfg_io.puts("dynamic_types = #{mpcdynamic.join(', ')}")
+            mpccfg_io.puts("dynamic_types = $TAOX11_ROOT/bin/MPC, #{mpcdynamic.join(', ')}")
             mpccfg_io.puts('main_functions = cplusplus:ACE_TMAIN')
           ensure
             mpccfg_io.close unless cfg.dryrun?

--- a/etc/configurerc
+++ b/etc/configurerc
@@ -92,6 +92,7 @@ configure :acetao do
 
   mpc do
     include %w{$MPC_ROOT/config $ACE_ROOT/bin/MakeProjectCreator/config}
+    dynamic_type %w{$MPC_ROOT $TAO_ROOT/MPC}
 
     mwc_include %w{
       $(ACE_ROOT)/ace


### PR DESCRIPTION
…brix11 collection

    * brix11/lib/brix11/brix/common/cmds/configure/configurator.rb:
    * brix11/lib/brix11/brix/common/cmds/configure/dsl.rb:
    * brix11/lib/brix11/brix/common/cmds/configure/mpc_config.rb:
    * etc/configurerc: