### PR TITLE
Removed $TAOX11_ROOT/bin/MPC as default dynamic_type, now comes throu…

### DIFF
--- a/brix11/lib/brix11/brix/common/cmds/configure/mpc_config.rb
+++ b/brix11/lib/brix11/brix/common/cmds/configure/mpc_config.rb
@@ -40,7 +40,7 @@ module BRIX11
             mpccfg_io = cfg.dryrun? ? STDOUT : File.new(mpccfg, 'w')
             mpccfg_io.puts("//----- #{MPCCFG} -----") if cfg.dryrun?
             mpccfg_io.puts("includes = #{mpcinc.join(', ')}")
-            mpccfg_io.puts("dynamic_types = $TAOX11_ROOT/bin/MPC, #{mpcdynamic.join(', ')}")
+            mpccfg_io.puts("dynamic_types = #{mpcdynamic.join(', ')}")
             mpccfg_io.puts('main_functions = cplusplus:ACE_TMAIN')
           ensure
             mpccfg_io.close unless cfg.dryrun?


### PR DESCRIPTION
…gh TAOX11

    * brix11/lib/brix11/brix/common/cmds/configure/mpc_config.rb: