### PR TITLE
No need to generate c++11 as default setting for the generated platfo…

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -105,38 +105,6 @@ jobs:
       run: |
         sudo apt-get --yes update
         sudo apt-get --yes install libxerces-c-dev libssl-dev ${{ matrix.PackageDeps }}
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2
-      with:
-        repository: DOCGroup/ACE_TAO
-        path: ${{ env.DOC_ROOT }}
-        ref: Latest_Micro
-    - name: checkout MPC
-      uses: actions/checkout@v2
-      with:
-        repository: DOCGroup/MPC
-        path: ${{ env.MPC_ROOT }}
-        ref: Latest_ACETAO_Micro
-    - name: checkout ridl
-      uses: actions/checkout@v2
-      with:
-        repository: RemedyIT/ridl
-        path: ${{ env.RIDL_ROOT }}
-    - name: checkout taox11
-      uses: actions/checkout@v2
-      with:
-        repository: RemedyIT/taox11
-        path: ${{ env.TAOX11_ROOT }}
-    - name: checkout ciaox11
-      uses: actions/checkout@v2
-      with:
-        repository: RemedyIT/ciaox11
-        path: ${{ env.CIAOX11_ROOT }}
-    - name: checkout dancex11
-      uses: actions/checkout@v2
-      with:
-        repository: RemedyIT/dancex11
-        path: ${{ env.DANCEX11_ROOT }}
     - name: Run brix11 configure
       run: |
         $X11_BASE_ROOT/bin/brix11 configure -W aceroot=$ACE_ROOT -W taoroot=$TAO_ROOT -W mpcroot=$MPC_ROOT

--- a/brix11/lib/brix11/brix/common/cmds/configure/hostsetup.rb
+++ b/brix11/lib/brix11/brix/common/cmds/configure/hostsetup.rb
@@ -105,7 +105,6 @@ module BRIX11
                 # generate default platform macros
                 platform_macros_io << %Q{
                   debug=0
-                  c++11=1
                   no_deprecated=0
                   inline=1
                   optimize=1

--- a/brix11/lib/brix11/brix/common/cmds/configure/platform.rb
+++ b/brix11/lib/brix11/brix/common/cmds/configure/platform.rb
@@ -55,7 +55,6 @@ module BRIX11
                                                   }.gsub(/^\s+/, ''),
                                                 gnumake_prelude: %Q{
                                                     debug=0
-                                                    c++11=1
                                                     no_deprecated=0
                                                     inline=1
                                                     optimize=1
@@ -121,7 +120,6 @@ module BRIX11
                                           gnumake_include: 'platform_linux.GNU',
                                           gnumake_prelude: %Q{
                                               debug=0
-                                              c++11=1
                                               no_deprecated=0
                                               inline=1
                                               optimize=1


### PR DESCRIPTION
…rm macros because it is now default enabled with ACE7, devportal 4865

    * brix11/lib/brix11/brix/common/cmds/configure/hostsetup.rb:
    * brix11/lib/brix11/brix/common/cmds/configure/platform.rb: