### PR TITLE
No need to set no_deprecated=0 because it is not enabled anymore by d…

### DIFF
--- a/brix11/lib/brix11/brix/common/cmds/configure/hostsetup.rb
+++ b/brix11/lib/brix11/brix/common/cmds/configure/hostsetup.rb
@@ -105,7 +105,6 @@ module BRIX11
                 # generate default platform macros
                 platform_macros_io << %Q{
                   debug=0
-                  no_deprecated=0
                   inline=1
                   optimize=1
                 }.gsub(/^\s+/, '')

--- a/brix11/lib/brix11/brix/common/cmds/configure/platform.rb
+++ b/brix11/lib/brix11/brix/common/cmds/configure/platform.rb
@@ -55,7 +55,6 @@ module BRIX11
                                                   }.gsub(/^\s+/, ''),
                                                 gnumake_prelude: %Q{
                                                     debug=0
-                                                    no_deprecated=0
                                                     inline=1
                                                     optimize=1
                                                   }.gsub(/^\s+/, '')
@@ -120,7 +119,6 @@ module BRIX11
                                           gnumake_include: 'platform_linux.GNU',
                                           gnumake_prelude: %Q{
                                               debug=0
-                                              no_deprecated=0
                                               inline=1
                                               optimize=1
                                             }.gsub(/^\s+/, '')


### PR DESCRIPTION
…efault due to the removal of c++11=1

    * brix11/lib/brix11/brix/common/cmds/configure/hostsetup.rb:
    * brix11/lib/brix11/brix/common/cmds/configure/platform.rb: