### PR TITLE
Valgrind 3.14 and newer support --keep-debug-info, older versions don't

### DIFF
--- a/etc/configurerc
+++ b/etc/configurerc
@@ -82,6 +82,18 @@ configure :acetao do
       end
       requires :valgrindcmd
     end
+
+    optional :valgrind_keep_debuginfo do
+      environment :valgrindcmd do
+        name 'ACE_RUN_VALGRIND_CMD'
+        description 'Executable name to be used for valgrind (required for valgrind integration)'
+      end
+      evaluate(:valgrind) do
+        valgrind_ver_ = `#{getenv('ACE_RUN_VALGRIND_CMD')} --version`.chomp.split("\n").first.split('valgrind-').last
+        valgrind_ver_ >= '3.14.0'
+      end
+      requires :valgrindcmd
+    end
   end
 
   features do


### PR DESCRIPTION
    * etc/configurerc: