### PR TITLE
Exclude ddsx11/vendors from TAOX11 namespace fuzz

### DIFF
--- a/bin/fuzzers/check_taox11_namespaces.excludes
+++ b/bin/fuzzers/check_taox11_namespaces.excludes
@@ -4,4 +4,5 @@ taox11\/tao\/.*
 taox11\/orbsvcs\/orbsvcs\/.*
 public\/.*(C|S|P|SP)\.(h|inl|cpp)
 ddsx11\/dds\/.*
+ddsx11\/vendors\/.*
 

--- a/bin/fuzzers/check_taox11_namespaces.excludes
+++ b/bin/fuzzers/check_taox11_namespaces.excludes
@@ -4,5 +4,4 @@ taox11\/tao\/.*
 taox11\/orbsvcs\/orbsvcs\/.*
 public\/.*(C|S|P|SP)\.(h|inl|cpp)
 ddsx11\/dds\/.*
-ddsx11\/vendors\/.*
-
+ddsx11\/vendors\/opendds\/dds\/.*


### PR DESCRIPTION
    * bin/fuzzers/check_taox11_namespaces.excludes: