### PR TITLE
Updated docu to use asciidoctor 2.0.15 as 2.0.16 dropped ruby 2.0 sup…

### DIFF
--- a/brix11/lib/brix11/brix/common/docs/generate_documentation.rd
+++ b/brix11/lib/brix11/brix/common/docs/generate_documentation.rd
@@ -23,4 +23,4 @@ common
 Generate documentation from Asciidoctor sources into the 'docs' directory. To install
 Asciidoctor with coderay support as gem run the following command
 
-$ gem install asciidoctor coderay
+$ gem install asciidoctor:2.0.15 coderay


### PR DESCRIPTION
…port

    * brix11/lib/brix11/brix/common/docs/generate_documentation.rd: