### PR TITLE
No need to force C++11 for yocto, gcc 7.3 has C++14 as default, let us just kee…

### DIFF
--- a/etc/yocto.json
+++ b/etc/yocto.json
@@ -16,7 +16,6 @@
   "gnumake_include": "platform_linux.GNU",
   "gnumake_prelude": [
     "debug=0",
-    "c++11=1",
     "no_deprecated=0",
     "inline=1",
     "optimize=1",

--- a/etc/yocto.json
+++ b/etc/yocto.json
@@ -16,7 +16,6 @@
   "gnumake_include": "platform_linux.GNU",
   "gnumake_prelude": [
     "debug=0",
-    "no_deprecated=0",
     "inline=1",
     "optimize=1",
     "boost=0"


### PR DESCRIPTION
…p the compiler default

    * etc/yocto.json: