### PR TITLE
Add transport/framework as directory we need to copy for the host set…

### DIFF
--- a/brix11/lib/brix11/brix/common/cmds/configure/hostsetup.rb
+++ b/brix11/lib/brix11/brix/common/cmds/configure/hostsetup.rb
@@ -51,6 +51,7 @@ module BRIX11
                 'dds/idl' => :norecurse,
                 'dds/DCPS' => :norecurse,
                 'dds/DCPS/XTypes' => :norecurse,
+                'dds/DCPS/transport/framework' => :norecurse,
                 'MPC' => :recurse
               }
             }


### PR DESCRIPTION
…up with OpenDDS 3.19

    * brix11/lib/brix11/brix/common/cmds/configure/hostsetup.rb: