### PR TITLE
Make bootstrap smarter

### DIFF
--- a/brix11/lib/brix11/brix/common/cmds/bootstrap.rb
+++ b/brix11/lib/brix11/brix/common/cmds/bootstrap.rb
@@ -64,7 +64,10 @@ module BRIX11
               Sys.in_dir(bse['dir']) do
                 tag = bse['tag'] || options[:bootstrap][:tags][bse['id']] || 'master'
                 rc, _, _ = Exec.runcmd('git', 'clone', bse['repo'], '.')
-                BRIX11.log_fatal("Failed to clone #{bse['id']} repository : #{bse['repo']}") unless rc
+                #XXX BRIX11.show_msg("Failed to clone #{bse['id']} repository : #{bse['repo']}") unless rc
+                rc, _, _ = Exec.runcmd('git', 'stash') unless rc
+                rc, _, _ = Exec.runcmd('git', 'fetch')
+                BRIX11.show_msg("Failed to fetch #{bse['id']} repository : #{bse['repo']}") unless rc
                 rc,_, _ = Exec.runcmd('git', 'checkout', tag)
                 BRIX11.log_fatal("Failed to checkout #{bse['id']} repository tag : #{tag}") unless rc
               end


### PR DESCRIPTION
This make it possible to update the current workspace to an other version based on the etc/brix11rc config file.