### PR TITLE
Enable multiprocessorcompilation on Windows, speeds up the compilation

### DIFF
--- a/brix11/lib/brix11/projects/msbuild.rb
+++ b/brix11/lib/brix11/projects/msbuild.rb
@@ -276,7 +276,7 @@ module BRIX11
     protected
 
       def extra_mpc_args
-        super.concat(%W(-value_template platforms="#{@compiler.platform}" -value_template PlatformToolset=#{@compiler.version}))
+        super.concat(%W(-value_template platforms="#{@compiler.platform}" -value_template PlatformToolset=#{@compiler.version} -value_template MultiProcessorCompilation=true))
       end
 
       def sln_for_dir(path)


### PR DESCRIPTION
    * brix11/lib/brix11/projects/msbuild.rb: