### PR TITLE
brix11: fix incorrect variable splitting

### DIFF
--- a/brix11/lib/brix11/base.rb
+++ b/brix11/lib/brix11/base.rb
@@ -158,7 +158,7 @@ module BRIX11
             'Define an additional environment variable for BRIX11 commands.',
             'Separate (optional) value by \'=\' like VAR=VAL. By default value will be \'1\'.',
             'Supports \$VAR and \${VAR}-form variable expansion.') { |v|
-      _var, _val = v.split('=')
+      _var, _val = v.split('=', 2)
       (options.user_config.user_environment ||= {})[_var] = _val || '1'
     }
     opts.on('-x', '--crossbuild',


### PR DESCRIPTION
Variable values containing an equal sign can't be used with the -D option due to incorrect splitting:

    $ bin/brix11 -D A=B=C environment
    export A=B

Output after applying the fix:

    $ bin/brix11 -D A=B=C environment
    export A=B=C

This fixes #122.