### PR TITLE
Update linux.yml

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -73,6 +73,7 @@ jobs:
             CXX: g++-13
             ruby: '3.2'
             PackageDeps: g++-13
+            Repo: ppa:ubuntu-toolchain-r/test
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} ${{ matrix.CXX }} ruby-${{ matrix.ruby }}
     env:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -68,12 +68,11 @@ jobs:
             CXX: g++-12
             ruby: '3.1'
             PackageDeps: g++-12
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             CC: gcc-13
             CXX: g++-13
             ruby: '3.2'
             PackageDeps: g++-13
-            Repo: ppa:ubuntu-toolchain-r/test
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} ${{ matrix.CXX }} ruby-${{ matrix.ruby }}
     env:


### PR DESCRIPTION
gcc-13 has been removed from ubuntu-22.04, see actions/runner-images#9866