### PR TITLE
Use gnuace MPC type for yocto

### DIFF
--- a/etc/yocto.json
+++ b/etc/yocto.json
@@ -5,7 +5,7 @@
   "dll_dir": "lib",
   "library_path_var": "LD_LIBRARY_PATH",
   "test_configs": ["LINUX", "Linux"],
-  "project_type": "gnuautobuild",
+  "project_type": "gnuace",
   "project_cc": "gnu",
   "config_include": "config-linux.h",
   "config_prelude": [


### PR DESCRIPTION
    * etc/yocto.json:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Adjusted the project configuration to update the internal project type designation, ensuring consistency across system parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->