### PR TITLE
Removed bootstrap support for AXCIOMA (ciaox11/dancex11) due to lack …

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3,16 +3,16 @@ image:https://www.codefactor.io/repository/github/remedyit/axcioma/badge[CodeFac
 image:https://github.com/RemedyIT/axcioma/workflows/linux/badge.svg[Linux CI, link=https://github.com/RemedyIT/axcioma/actions?query=workflow%3Alinux]
 image:https://github.com/RemedyIT/axcioma/workflows/fuzzr/badge.svg[Fuzzr CI, link=https://github.com/RemedyIT/axcioma/actions?query=workflow%3Afuzzr]
 
-= Building AXCIOMA or TAOX11
+= Building TAOX11
 
-This is the main repository for https://www.taox11.org[TAOX11] and https://www.axcioma.org[AXCIOMA].
-AXCIOMA and TAOX11 are created and maintained by https://www.remedy.nl[Remedy IT].
+This is the main repository for https://www.taox11.org[TAOX11].
+TAOX11 is created and maintained by https://www.remedy.nl[Remedy IT].
 This repository contains the bootstrap tooling to obtain TAOX11 and to generate the necessary
 configuration using link:brix11/docs/src/brix11.adoc[BRIX11].
 
 == Prerequisites
 
-Before bootstrapping AXCIOMA make sure you have installed the following prerequisites
+Before bootstrapping TAOX11 make sure you have installed the following prerequisites
 
 [cols="<,<",options="header",]
 |=========================================
@@ -59,11 +59,7 @@ The configure step generates the necessary configuration files for the specified
 
 NOTE: Configure doesn't use your current environment, when you want configure to use your current environment
 use `bin/brix11 -E configure`. When using the `-E` switch you have to keep in mind you will have to keep using
-that switch when building project files, running make and running tests. +
-As alternative you can specify configuration variables as argument to configure,
-for example `-W nddshome=<dir> -W nddsarch=<arch>` to specify the
-RTI Connext DDS home and architecture or `-W openddsroot=<dir>` to specify the location of the OpenDDS sources.
-This will cause the settings to be stored in the BRIX11 configuration.
+that switch when building project files, running make and running tests.
 The `bin/brix11 env` command will show you all environment variables set up by BRIX11.
 
 === Generate build artifacts

--- a/README.adoc
+++ b/README.adoc
@@ -7,7 +7,7 @@ image:https://github.com/RemedyIT/axcioma/workflows/fuzzr/badge.svg[Fuzzr CI, li
 
 This is the main repository for https://www.taox11.org[TAOX11] and https://www.axcioma.org[AXCIOMA].
 AXCIOMA and TAOX11 are created and maintained by https://www.remedy.nl[Remedy IT].
-This repository contains the bootstrap tooling to obtain TAOX11 or AXCIOMA and to generate the necessary
+This repository contains the bootstrap tooling to obtain TAOX11 and to generate the necessary
 configuration using link:brix11/docs/src/brix11.adoc[BRIX11].
 
 == Prerequisites
@@ -51,10 +51,6 @@ TAOX11 is the default target for bootstrapping. The bootstrap command will clone
 
  bin/brix11 bootstrap
 
-AXCIOMA can be specified as optional target, which is done using
-
- bin/brix11 bootstrap axcioma
-
 === Configure
 
 The configure step generates the necessary configuration files for the specified target (execute `bin/brix11 help configure` for more details). The configure step is performed by executing
@@ -89,7 +85,7 @@ User documentation can be generated after the `brix11 configure` command using h
  bin/brix11 generate documentation
 
 After generation the documentation can be found under `docs/html`. A good place to start reading is the `getting_started.html`
-document (either under `docs/html/taox11` for TAOX11 or `docs/html/ciaox11` for AXCIOMA).
+document (under `docs/html/taox11` for TAOX11).
 
 == Building formal releases
 

--- a/brix11/lib/brix11/brix/common/cmds/bootstrap.rb
+++ b/brix11/lib/brix11/brix/common/cmds/bootstrap.rb
@@ -23,17 +23,14 @@ module BRIX11
         optparser.banner = "#{DESC}\n\n" +
                            "Usage: #{options[:script_name]} bootstrap [TARGET] [options]\n\n" +
                            "       TARGET := Target component collection to bootstrap. Supported:\n" +
-                           "                 taox11\tBootstraps solely the TAOX11 framework components (default)\n" +
-                           "                 axcioma\tBootstraps the AXCIOMA framework components\n\n"
+                           "                 taox11\tBootstraps solely the TAOX11 framework components (default)\n\n"
 
         optparser.on('-t', '--tag', '=COMPONENT:TAG', String, 'Override default repository tags for framework components.',
                                                               'Specify as <component id>:<tag>. Supported components:',
                                                               "ACE\tDOC Group ACE + TAO repository",
                                                               "MPC\tDOC Group MPC repository",
                                                               "ridl\tRIDL IDL compiler frontend",
-                                                              "taox11\tTAOX11 C++11 CORBA ORB repository",
-                                                              "ciaox11\tCIAOX11 C++11 LwCCM repository",
-                                                              "dancex11\tDANCEX11 C++11 D&C repository") do |v|
+                                                              "taox11\tTAOX11 C++11 CORBA ORB repository") do |v|
           id, tag = v.split(':')
           BRIX11.log_fatal("Missing required tag for component in [--tag #{v}].") unless tag
           options[:bootstrap][:tags][id] = tag

--- a/brix11/lib/brix11/brix/common/docs/bootstrap.rd
+++ b/brix11/lib/brix11/brix/common/docs/bootstrap.rd
@@ -11,7 +11,6 @@ common
 
   TARGET := Target component collection to bootstrap. Supported:
             taox11         Bootstraps solely the TAOX11 framework components (default)
-            axcioma        Bootstraps the AXCIOMA framework components
 
 === options
 
@@ -21,8 +20,6 @@ common
                                    MPC        DOC Group MPC repository
                                    ridl       RIDL IDL compiler frontend
                                    taox11     TAOX11 C++11 CORBA ORB repository
-                                   ciaox11    CIAOX11 C++11 LwCCM repository
-                                   dancex11   DAnCEX11 C++11 D&C repository
 
   -f, --force                      Force all tasks to run even if their dependencies do not require them to.
                                    Default: off

--- a/etc/brix11rc
+++ b/etc/brix11rc
@@ -3,8 +3,6 @@
     { "id": "ACE", "collections": ["TAOX11", "AXCIOMA"], "dir": "ACE", "repo": "https://github.com/DOCGroup/ACE_TAO.git", "tag": "ACE+TAO-8_0_2" },
     { "id": "MPC", "collections": ["TAOX11", "AXCIOMA"], "dir": "ACE/MPC", "repo": "https://github.com/DOCGroup/MPC.git", "tag": "ACE+TAO-8_0_2" },
     { "id": "ridl", "collections": ["TAOX11", "AXCIOMA"], "dir": "ridl", "repo": "https://github.com/RemedyIT/ridl.git", "tag": "master" },
-    { "id": "taox11", "collections": ["TAOX11", "AXCIOMA"], "dir": "taox11", "repo": "https://github.com/RemedyIT/taox11.git", "tag": "master" },
-    { "id": "ciaox11", "collections": ["AXCIOMA"], "dir": "ciaox11", "repo": "https://github.com/RemedyIT/ciaox11.git", "tag": "master" },
-    { "id": "dancex11", "collections": ["AXCIOMA"], "dir": "dancex11", "repo": "https://github.com/RemedyIT/dancex11.git", "tag": "master" }
+    { "id": "taox11", "collections": ["TAOX11", "AXCIOMA"], "dir": "taox11", "repo": "https://github.com/RemedyIT/taox11.git", "tag": "master" }
   ]
 }


### PR DESCRIPTION
…of sponsoring to maintain it, from this moment only TAOX11 can be bootstrapped

    * README.adoc:
    * brix11/lib/brix11/brix/common/cmds/bootstrap.rb:
    * brix11/lib/brix11/brix/common/docs/bootstrap.rd:
    * etc/brix11rc:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Streamlined repository documentation and setup instructions to focus solely on the supported framework, removing outdated references to additional components.
	- Simplified bootstrapping guides and command-line help for a clearer and more focused user experience.

- **Chores**
	- Updated configuration settings by removing entries for deprecated components, ensuring that only relevant options are displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->